### PR TITLE
Add zeroconf support, bug fixes for TiVo remote protocol errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,21 @@ media_player:
 1. Set debug to 1 for additional logging
 2. Do not add zapuser/zappass to configuration.yaml unless you have a valid Zap2iT account.
 Add your zap2it password into secrets.yaml - note that our example does not encode the password, which you can change:
+
 ```
 zap2it_pass: whateverYouChose
 ```
 
+You can also let the tivo component use zeroconf configuration to find and construct your TiVo entities.  Just remove the `host` key.  In this case, the configuration would look like:
+
+```
+media_player:
+  - platform: tivo
+#    zapuser: your_zaptoit_email_login
+#    zappass: !secret zap2it_pass
+```
+
+The entity names will be the name of the TiVo unit with the string `_tivo` added to the end.  You can customize the entity names in the `customization.yaml` file.  If you need to change the TiVo port for a specific unit, you can't use the zeroconf configuration.
 
 This works by opening a socket connection to the Tivo device on its default port 31339.  Then using the following protocol, it can perform several commands:
 

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,0 +1,13 @@
+{
+    "tivo": {
+        "version": "0.0.2",
+        "local_location": "/custom_components/tivo/__init__.py",
+        "remote_location": "https://raw.githubusercontent.com/jcollas/homeassistant_tivo/master/tivo/__init__.py",
+        "visit_repo": "https://github.com/jcollas/homeassistant_tivo",
+        "changelog": "https://github.com/jcollas/homeassistant_tivo/wiki/Changelog",
+        "resources": [
+            "https://raw.githubusercontent.com/jcollas/homeassistant_tivo/master/tivo/media_player.py",
+            "https://raw.githubusercontent.com/jcollas/homeassistant_tivo/master/tivo/manifest.json"
+        ]
+    }
+}

--- a/custom_components.json
+++ b/custom_components.json
@@ -2,12 +2,12 @@
     "tivo": {
         "version": "0.0.2",
         "local_location": "/custom_components/tivo/__init__.py",
-        "remote_location": "https://raw.githubusercontent.com/jcollas/homeassistant_tivo/master/tivo/__init__.py",
-        "visit_repo": "https://github.com/jcollas/homeassistant_tivo",
-        "changelog": "https://github.com/jcollas/homeassistant_tivo/wiki/Changelog",
+        "remote_location": "https://raw.githubusercontent.com/groupwhere/homeassistant-tivo/master/tivo/__init__.py",
+        "visit_repo": "https://github.com/groupwhere/homeassistant-tivo",
+        "changelog": "https://github.com/groupwhere/homeassistant-tivo/wiki/Changelog",
         "resources": [
-            "https://raw.githubusercontent.com/jcollas/homeassistant_tivo/master/tivo/media_player.py",
-            "https://raw.githubusercontent.com/jcollas/homeassistant_tivo/master/tivo/manifest.json"
+            "https://raw.githubusercontent.com/groupwhere/homeassistant-tivo/master/tivo/media_player.py",
+            "https://raw.githubusercontent.com/groupwhere/homeassistant-tivo/master/tivo/manifest.json"
         ]
     }
 }

--- a/tivo/__init__.py
+++ b/tivo/__init__.py
@@ -1,0 +1,6 @@
+"""
+Support for the Tivo receivers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/tivo/
+"""


### PR DESCRIPTION
 * Added zeroconf configuration to simplify overall tivo configuration if the home has several tivos
 * Made ‘host' config parameter optional to kick off zeroconf configuration
 * Made media_control look nicer, TiVo shows in standby mode (Returns STATUS_STANDBY instead of STATUS_OFF)
 * Caught case where TiVo returns ‘no_channel Video’ from the status request