### PR TITLE
Fix for cable channels below 1000.

### DIFF
--- a/custom_components/tivo/media_player.py
+++ b/custom_components/tivo/media_player.py
@@ -277,6 +277,7 @@ class TivoDevice(MediaPlayerDevice):
                 status = words[3]
             else:
                 channel = words[1].lstrip("0")
+                channel = channel.zfill(4)
                 status = words[2]
 
             self._current["channel"] = channel


### PR DESCRIPTION
This should fix the problem with zap2it data not being returned for cable channels < 1000.